### PR TITLE
u-boot-fslc: fix 2016.09 revision

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc_2016.09.bb
+++ b/recipes-bsp/u-boot/u-boot-fslc_2016.09.bb
@@ -2,5 +2,5 @@ include u-boot-fslc.inc
 
 PV = "v2016.09+git${SRCPV}"
 
-SRCREV = "0dea106b4985c15c055e7ae187b05a53d6a82a41"
+SRCREV = "0dbe8538b73b402faa7e0b873d3c69857b76a35c"
 SRCBRANCH = "2016.09+fslc"


### PR DESCRIPTION
In commit e4bc3c3197103efb09f653ca655416181e07cea1 the SRCREV was updated for the 2016.09 recipe. But that revision does not exist in tree.

Update to latest revision SHA-1